### PR TITLE
Zeek 7.1 compatibility changes

### DIFF
--- a/tests/analyzer/tailscale.zeek
+++ b/tests/analyzer/tailscale.zeek
@@ -1,5 +1,5 @@
 # @TEST-EXEC: zeek -C -r ${TRACES}/tailscale_linux.pcap %INPUT
-# @TEST-EXEC: cat conn.log | zeek-cut -m -n local_orig local_resp >conn.log.filtered
+# @TEST-EXEC: zeek-cut -m -n local_orig local_resp ip_proto < conn.log > conn.log.filtered
 # @TEST-EXEC: btest-diff conn.log.filtered
 # @TEST-EXEC: btest-diff .stdout
 #

--- a/tests/analyzer/wireguard.zeek
+++ b/tests/analyzer/wireguard.zeek
@@ -1,5 +1,5 @@
 # @TEST-EXEC: zeek -C -r ${TRACES}/wireguard.pcap %INPUT
-# @TEST-EXEC: cat conn.log | zeek-cut -m -n local_orig local_resp >conn.log.filtered
+# @TEST-EXEC: zeek-cut -m -n local_orig local_resp ip_proto < conn.log > conn.log.filtered
 # @TEST-EXEC: btest-diff conn.log.filtered
 # @TEST-EXEC: btest-diff wireguard.log
 # @TEST-EXEC: btest-diff .stdout


### PR DESCRIPTION
Zeek 7.1 introduced the 'ip_proto' field in the conn.log. To maintain consistent baselines across Zeek 7 versions, cut the ip_proto field in affected btests.